### PR TITLE
feat(handler-aws): http request middleware

### DIFF
--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -1,0 +1,37 @@
+on:
+  push:
+    branches:
+      - main
+      - next
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - run: node -v
+      - run: npm -v
+
+      - uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - run: npm ci --no-scripts
+
+      - run: make code
+      - run: make test
+      - run: make build

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -1,3 +1,5 @@
+name: Build Project
+
 on:
   push:
     branches:

--- a/Makefile
+++ b/Makefile
@@ -88,9 +88,6 @@ build.compile.clean:
 	find ./${DIR_BUILD_WORKSPACE} -type f -name "*.proof.js" -delete
 	find ./${DIR_BUILD_WORKSPACE} -type f -name "*.proof.d.ts" -delete
 
-	find ./${DIR_BUILD_WORKSPACE} -type f -name "examples/*" -delete
-	find ./${DIR_BUILD_WORKSPACE} -type d -name "examples" -delete
-
 build.compile.verify:
 	test -d ./${DIR_BUILD_WORKSPACE}
 	test -d ./${DIR_BUILD_WORKSPACE}/@phasma/handler

--- a/package-lock.json
+++ b/package-lock.json
@@ -1365,9 +1365,9 @@
       }
     },
     "node_modules/@matt-usurp/grok": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@matt-usurp/grok/-/grok-0.5.4.tgz",
-      "integrity": "sha512-N8Lrl/hexMzTNzTDFYPTXkBRYnIplv2N3nY+eqlHsKz1lSiG9zRFN3L0gw9WXpzM5hGPpk7gYwcBr+ZAqifPfg=="
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@matt-usurp/grok/-/grok-0.6.1.tgz",
+      "integrity": "sha512-TLAMk97Jte+4fsbWJp9agfg4wC1Kz0+OnDNphOGR1eCrc9vLNNaWHnRnO5V/PR/FBpBxYUPZ+TjeSek41ZWaKg=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -6791,7 +6791,7 @@
     "packages/@phasma/handler": {
       "version": "0.2.2",
       "dependencies": {
-        "@matt-usurp/grok": "^0.5.4",
+        "@matt-usurp/grok": "^0.6.1",
         "@types/aws-lambda": "^8.10.93"
       },
       "devDependencies": {
@@ -6809,7 +6809,7 @@
     "packages/@phasma/handler-aws": {
       "version": "0.3.3",
       "dependencies": {
-        "@matt-usurp/grok": "^0.5.4",
+        "@matt-usurp/grok": "^0.6.1",
         "@phasma/handler": "^0.2.2"
       },
       "devDependencies": {
@@ -7888,9 +7888,9 @@
       }
     },
     "@matt-usurp/grok": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@matt-usurp/grok/-/grok-0.5.4.tgz",
-      "integrity": "sha512-N8Lrl/hexMzTNzTDFYPTXkBRYnIplv2N3nY+eqlHsKz1lSiG9zRFN3L0gw9WXpzM5hGPpk7gYwcBr+ZAqifPfg=="
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@matt-usurp/grok/-/grok-0.6.1.tgz",
+      "integrity": "sha512-TLAMk97Jte+4fsbWJp9agfg4wC1Kz0+OnDNphOGR1eCrc9vLNNaWHnRnO5V/PR/FBpBxYUPZ+TjeSek41ZWaKg=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -7921,7 +7921,7 @@
     "@phasma/handler": {
       "version": "file:packages/@phasma/handler",
       "requires": {
-        "@matt-usurp/grok": "^0.5.4",
+        "@matt-usurp/grok": "^0.6.1",
         "@types/aws-lambda": "^8.10.93",
         "@types/qs": "^6.9.7"
       }
@@ -7929,7 +7929,7 @@
     "@phasma/handler-aws": {
       "version": "file:packages/@phasma/handler-aws",
       "requires": {
-        "@matt-usurp/grok": "^0.5.4",
+        "@matt-usurp/grok": "^0.6.1",
         "@phasma/handler": "^0.2.2",
         "@types/aws-lambda": "^8.10.91"
       }

--- a/packages/@phasma/handler-aws/examples/handler-lambda-apigw-http-advanced-verbose.ts
+++ b/packages/@phasma/handler-aws/examples/handler-lambda-apigw-http-advanced-verbose.ts
@@ -1,0 +1,88 @@
+import { HttpRequestBodyValidatorContext, HttpRequestBodyValidatorMiddleware } from '@phasma/handler-aws/src/http/middlware/http-request-body-validator';
+import { HttpRequestPathValidatorContext, HttpRequestPathValidatorMiddleware } from '@phasma/handler-aws/src/http/middlware/http-request-path-validator';
+import { HttpRequesQueryValidatorMiddleware, HttpRequestQueryValidatorContext } from '@phasma/handler-aws/src/http/middlware/http-request-query-validator';
+import { HttpResponseBodyEncoderMiddleware } from '@phasma/handler-aws/src/http/middlware/http-response-body-encoder';
+import { HttpResponseTransformerMiddleware } from '@phasma/handler-aws/src/http/middlware/http-response-transformer';
+import { aws, Event, Handler } from '@phasma/handler-aws/src/index';
+import * as json from '@phasma/handler/src/http/body/json';
+import * as query from '@phasma/handler/src/http/query';
+import { http, HttpResponse, HttpResponseTransport } from '@phasma/handler/src/http/response';
+import * as zod from '@phasma/handler/src/http/validator/zod';
+import { z } from 'zod';
+
+type EventSourceIdentifier = Event.Source<'apigw:proxy:v2'>;
+
+type ExampleRequestPath = {
+  user: string;
+};
+
+type ExampleRequestQuery = {
+  page: number;
+  limit: number;
+};
+
+type ExampleRequestBody = {
+  name: string;
+};
+
+type ExampleResponseBody = {
+  name: string;
+};
+
+type ExampleResponse = HttpResponseTransport<200, ExampleResponseBody>;
+
+type Context = (
+  & HttpRequestPathValidatorContext<ExampleRequestPath>
+  & HttpRequestQueryValidatorContext<ExampleRequestQuery>
+  & HttpRequestBodyValidatorContext<ExampleRequestBody>
+);
+
+type Definition = Handler.Definition<EventSourceIdentifier, Context, HttpResponse<ExampleResponse>>;
+
+/**
+ * @endpoint POST /users/{user}
+ */
+export class ExampleHandler implements Handler.Implementation<Definition> {
+  public async handle({ context }: Handler.Fn.Parameters<Definition>): Handler.Fn.Response<Definition> {
+    context.path.user; // from HttpRequestPathValidatorMiddleware
+    context.body.name; // from HttpRequestBodyValidatorMiddleware
+
+    context.query.page; // from HttpRequesQueryValidatorMiddleware
+    context.query.limit; // from HttpRequesQueryValidatorMiddleware
+
+    return http<ExampleResponse>({
+      status: 200,
+      body: {
+        name: context.body.name,
+      },
+    });
+  }
+}
+
+export const target = aws<EventSourceIdentifier>(async (application) => (
+  application
+    .use(HttpResponseTransformerMiddleware.create())
+    .use(HttpResponseBodyEncoderMiddleware.create(json.encode))
+    .use(HttpRequestPathValidatorMiddleware.create<ExampleRequestPath>(zod.validate<ExampleRequestPath>(
+      z.object<zod.FromType<ExampleRequestPath>>({
+        user: z.string().uuid(),
+      }),
+    )))
+    .use(HttpRequesQueryValidatorMiddleware.create<ExampleRequestQuery>(query.parse, zod.validate<ExampleRequestQuery>(
+      z.object<zod.FromType<ExampleRequestQuery>>({
+        page: z.number(),
+        limit: z.number(),
+      }),
+    )))
+    .use(HttpRequestBodyValidatorMiddleware.create<ExampleRequestBody>(json.decode, zod.validate<ExampleRequestBody>(
+      z.object<zod.FromType<ExampleRequestBody>>({
+        name: z.string().nonempty(),
+      }),
+    )))
+    .handle(new ExampleHandler())
+));
+
+// target(
+//   {} // as require('aws-lambda').APIGatewayProxyEventV2,
+//   {} // as require('aws-lambda').Context,
+// );

--- a/packages/@phasma/handler-aws/examples/handler-lambda-apigw-http-advanced.ts
+++ b/packages/@phasma/handler-aws/examples/handler-lambda-apigw-http-advanced.ts
@@ -1,0 +1,86 @@
+import { HttpRequestBodyValidatorContext, HttpRequestBodyValidatorMiddleware } from '@phasma/handler-aws/src/http/middlware/http-request-body-validator';
+import { HttpRequestPathValidatorContext, HttpRequestPathValidatorMiddleware } from '@phasma/handler-aws/src/http/middlware/http-request-path-validator';
+import { HttpRequesQueryValidatorMiddleware, HttpRequestQueryValidatorContext } from '@phasma/handler-aws/src/http/middlware/http-request-query-validator';
+import { HttpResponseBodyEncoderMiddleware } from '@phasma/handler-aws/src/http/middlware/http-response-body-encoder';
+import { HttpResponseTransformerMiddleware } from '@phasma/handler-aws/src/http/middlware/http-response-transformer';
+import { aws, Event, Handler } from '@phasma/handler-aws/src/index';
+import { http, HttpResponse, HttpResponseTransport } from '@phasma/handler/src/http/response';
+import type { FromType } from '@phasma/handler/src/http/validator/zod';
+import { z } from 'zod';
+
+type EventSourceIdentifier = Event.Source<'apigw:proxy:v2'>;
+
+type ExampleRequestPath = {
+  user: string;
+};
+
+type ExampleRequestQuery = {
+  page: number;
+  limit: number;
+};
+
+type ExampleRequestBody = {
+  name: string;
+};
+
+type ExampleResponseBody = {
+  name: string;
+};
+
+type ExampleResponse = HttpResponseTransport<200, ExampleResponseBody>;
+
+type Context = (
+  & HttpRequestPathValidatorContext<ExampleRequestPath>
+  & HttpRequestQueryValidatorContext<ExampleRequestQuery>
+  & HttpRequestBodyValidatorContext<ExampleRequestBody>
+);
+
+type Definition = Handler.Definition<EventSourceIdentifier, Context, HttpResponse<ExampleResponse>>;
+
+/**
+ * @endpoint POST /users/{user}
+ */
+export class ExampleHandler implements Handler.Implementation<Definition> {
+  public async handle({ context }: Handler.Fn.Parameters<Definition>): Handler.Fn.Response<Definition> {
+    context.path.user; // from HttpRequestPathValidatorMiddleware
+    context.body.name; // from HttpRequestBodyValidatorMiddleware
+
+    context.query.page; // from HttpRequesQueryValidatorMiddleware
+    context.query.limit; // from HttpRequesQueryValidatorMiddleware
+
+    return http<ExampleResponse>({
+      status: 200,
+      body: {
+        name: context.body.name,
+      },
+    });
+  }
+}
+
+export const target = aws<EventSourceIdentifier>(async (application) => (
+  application
+    .use(HttpResponseTransformerMiddleware.create())
+    .use(HttpResponseBodyEncoderMiddleware.json())
+    .use(HttpRequestPathValidatorMiddleware.zod<ExampleRequestPath>(
+      z.object<FromType<ExampleRequestPath>>({
+        user: z.string().uuid(),
+      }),
+    ))
+    .use(HttpRequesQueryValidatorMiddleware.zod<ExampleRequestQuery>(
+      z.object<FromType<ExampleRequestQuery>>({
+        page: z.number(),
+        limit: z.number(),
+      }),
+    ))
+    .use(HttpRequestBodyValidatorMiddleware.zod<ExampleRequestBody>(
+      z.object<FromType<ExampleRequestBody>>({
+        name: z.string().nonempty(),
+      }),
+    ))
+    .handle(new ExampleHandler())
+));
+
+// target(
+//   {} // as require('aws-lambda').APIGatewayProxyEventV2,
+//   {} // as require('aws-lambda').Context,
+// );

--- a/packages/@phasma/handler-aws/examples/handler-lambda-apigw-http.ts
+++ b/packages/@phasma/handler-aws/examples/handler-lambda-apigw-http.ts
@@ -1,7 +1,7 @@
-import { HttpBodyTransformerMiddleware } from '@phasma/handler-aws/src/http/middlware/http-body-transformer';
-import { HttpTransformerMiddleware } from '@phasma/handler-aws/src/http/middlware/http-transformer';
+import { HttpResponseBodyEncoderMiddleware } from '@phasma/handler-aws/src/http/middlware/http-response-body-encoder';
+import { HttpResponseTransformerMiddleware } from '@phasma/handler-aws/src/http/middlware/http-response-transformer';
 import { aws, Event, Handler } from '@phasma/handler-aws/src/index';
-import { json } from '@phasma/handler/src/http/body';
+import * as json from '@phasma/handler/src/http/body/json';
 import { http, HttpResponse, HttpResponseTransport } from '@phasma/handler/src/http/response';
 
 type EventSourceIdentifier = Event.Source<'apigw:proxy:v2'>;
@@ -25,8 +25,8 @@ export class ExampleHandler implements Handler.Implementation<Definition> {
 
 export const target = aws<EventSourceIdentifier>(async (application) => (
   application
-    .use(new HttpTransformerMiddleware())
-    .use(new HttpBodyTransformerMiddleware(json))
+    .use(HttpResponseTransformerMiddleware.create())
+    .use(HttpResponseBodyEncoderMiddleware.create(json.encode))
     .handle(new ExampleHandler())
 ));
 

--- a/packages/@phasma/handler-aws/package.json
+++ b/packages/@phasma/handler-aws/package.json
@@ -30,7 +30,7 @@
     }
   ],
   "dependencies": {
-    "@matt-usurp/grok": "^0.5.4",
+    "@matt-usurp/grok": "^0.6.1",
     "@phasma/handler": "^0.2.2"
   },
   "devDependencies": {

--- a/packages/@phasma/handler-aws/src/http/middlware/http-request-body-validator.test.ts
+++ b/packages/@phasma/handler-aws/src/http/middlware/http-request-body-validator.test.ts
@@ -1,0 +1,380 @@
+import type { Grok } from '@matt-usurp/grok';
+import { fn, partial } from '@matt-usurp/grok/testing';
+import type { HandlerResponseConstraint } from '@phasma/handler/src/component/response';
+import type { HttpBodyDecoder } from '@phasma/handler/src/http/body';
+import type { HttpValidatorFunction, HttpValidatorFunctionResultFailure, HttpValidatorFunctionResultSuccess } from '@phasma/handler/src/http/validator';
+import { FromType } from '@phasma/handler/src/http/validator/zod';
+import { z, ZodIssue } from 'zod';
+import type { Event } from '../../index';
+import { HttpRequestBodyValidatorContext, HttpRequestBodyValidatorErrorResponse, HttpRequestBodyValidatorMiddleware } from './http-request-body-validator';
+
+describe(HttpRequestBodyValidatorMiddleware.name, (): void => {
+  describe('create()', (): void => {
+    it('with payload, undefined, return error', async (): Promise<void> => {
+      const decoder = fn<HttpBodyDecoder<Grok.Constraint.Anything>>();
+      const validator = fn<HttpValidatorFunction<Grok.Constraint.Anything, unknown>>();
+
+      const middleware = HttpRequestBodyValidatorMiddleware.create(decoder, validator);
+
+      const next = jest.fn();
+
+      expect(
+        await middleware.invoke({
+          provider: {
+            id: 'provider:aws',
+
+            payload: partial<Event.Payload<'apigw:proxy:v2'>>({
+              body: undefined,
+            }),
+          },
+
+          context: 'given-context' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+          next,
+        }),
+      ).toStrictEqual<HttpRequestBodyValidatorErrorResponse>({
+        type: 'response:http',
+
+        value: {
+          status: 400,
+          body: undefined,
+        },
+      });
+
+      expect(decoder).toBeCalledTimes(0);
+      expect(validator).toBeCalledTimes(0);
+
+      expect(next).toBeCalledTimes(0);
+    });
+
+    it('with payload, empty string, return error', async (): Promise<void> => {
+      const decoder = fn<HttpBodyDecoder<Grok.Constraint.Anything>>();
+      const validator = fn<HttpValidatorFunction<Grok.Constraint.Anything, unknown>>();
+
+      const middleware = HttpRequestBodyValidatorMiddleware.create(decoder, validator);
+
+      const next = jest.fn();
+
+      expect(
+        await middleware.invoke({
+          provider: {
+            id: 'provider:aws',
+
+            payload: partial<Event.Payload<'apigw:proxy:v2'>>({
+              body: '',
+            }),
+          },
+
+          context: 'given-context' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+          next,
+        }),
+      ).toStrictEqual<HttpRequestBodyValidatorErrorResponse>({
+        type: 'response:http',
+
+        value: {
+          status: 400,
+          body: undefined,
+        },
+      });
+
+      expect(decoder).toBeCalledTimes(0);
+      expect(validator).toBeCalledTimes(0);
+
+      expect(next).toBeCalledTimes(0);
+    });
+
+    it('with payload, decoder returns error, return error', async (): Promise<void> => {
+      const decoder = fn<HttpBodyDecoder<Grok.Constraint.Anything>>();
+      const validator = fn<HttpValidatorFunction<Grok.Constraint.Anything, unknown>>();
+
+      decoder.mockImplementationOnce((value: string): undefined => {
+        expect(value).toStrictEqual('value:provider:payload:body:malformed');
+
+        return undefined;
+      });
+
+      const middleware = HttpRequestBodyValidatorMiddleware.create(decoder, validator);
+
+      const next = jest.fn();
+
+      expect(
+        await middleware.invoke({
+          provider: {
+            id: 'provider:aws',
+
+            payload: partial<Event.Payload<'apigw:proxy:v2'>>({
+              body: 'value:provider:payload:body:malformed',
+            }),
+          },
+
+          context: 'given-context' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+          next,
+        }),
+      ).toStrictEqual<HttpRequestBodyValidatorErrorResponse>({
+        type: 'response:http',
+
+        value: {
+          status: 400,
+          body: undefined,
+        },
+      });
+
+      expect(decoder).toBeCalledTimes(1);
+      expect(validator).toBeCalledTimes(0);
+
+      expect(next).toBeCalledTimes(0);
+    });
+
+    it('with payload, decodes, validator returns error, return error', async (): Promise<void> => {
+      const decoder = fn<HttpBodyDecoder<Grok.Constraint.Anything>>();
+      const validator = fn<HttpValidatorFunction<Grok.Constraint.Anything, unknown>>();
+
+      decoder.mockImplementationOnce((value: string): unknown => {
+        expect(value).toStrictEqual('value:provider:payload:body:invalid');
+
+        return 'test-action:decoder:success';
+      });
+
+      validator.mockImplementationOnce((value: unknown): HttpValidatorFunctionResultFailure<unknown> => {
+        expect(value).toStrictEqual('test-action:decoder:success');
+
+        return {
+          success: false,
+          errors: 'test-action:validator:errors',
+        };
+      });
+
+      const middleware = HttpRequestBodyValidatorMiddleware.create(decoder, validator);
+
+      const next = jest.fn();
+
+      expect(
+        await middleware.invoke({
+          provider: {
+            id: 'provider:aws',
+
+            payload: partial<Event.Payload<'apigw:proxy:v2'>>({
+              body: 'value:provider:payload:body:invalid',
+            }),
+          },
+
+          context: 'given-context' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+          next,
+        }),
+      ).toStrictEqual<HttpRequestBodyValidatorErrorResponse>({
+        type: 'response:http',
+
+        value: {
+          status: 400,
+          body: 'test-action:validator:errors',
+        },
+      });
+
+      expect(decoder).toBeCalledTimes(1);
+      expect(validator).toBeCalledTimes(1);
+
+      expect(next).toBeCalledTimes(0);
+    });
+
+    it('with payload, decodes, validates, invokes next with context', async (): Promise<void> => {
+      const decoder = fn<HttpBodyDecoder<Grok.Constraint.Anything>>();
+      const validator = fn<HttpValidatorFunction<Grok.Constraint.Anything, unknown>>();
+
+      decoder.mockImplementationOnce((value: string): unknown => {
+        expect(value).toStrictEqual('value:provider:payload:body:valid');
+
+        return 'test-action:decoder:success';
+      });
+
+      validator.mockImplementationOnce((value: unknown): HttpValidatorFunctionResultSuccess<unknown> => {
+        expect(value).toStrictEqual('test-action:decoder:success');
+
+        return {
+          success: true,
+          data: 'test-action:validator:success',
+        };
+      });
+
+      const middleware = HttpRequestBodyValidatorMiddleware.create(decoder, validator);
+
+      const next = jest.fn();
+
+      next.mockImplementationOnce(async (context: HttpRequestBodyValidatorContext<unknown>): Promise<HandlerResponseConstraint> => {
+        expect(context.body).toStrictEqual('test-action:validator:success');
+
+        return {
+          type: 'response:example',
+          value: 'test-action:middleware:next:success',
+        };
+      });
+
+      expect(
+        await middleware.invoke({
+          provider: {
+            id: 'provider:aws',
+
+            payload: partial<Event.Payload<'apigw:proxy:v2'>>({
+              body: 'value:provider:payload:body:valid',
+            }),
+          },
+
+          context: 'given-context' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+          next,
+        }),
+      ).toStrictEqual<HandlerResponseConstraint>({
+        type: 'response:example',
+        value: 'test-action:middleware:next:success',
+      });
+
+      expect(decoder).toBeCalledTimes(1);
+      expect(validator).toBeCalledTimes(1);
+
+      expect(next).toBeCalledTimes(1);
+    });
+  });
+
+  describe('zod()', (): void => {
+    it('with body, json malformed, returns error', async (): Promise<void> => {
+      type TestBodyMapping = {
+        name: string;
+        age: number;
+      };
+
+      const middleware = HttpRequestBodyValidatorMiddleware.zod<TestBodyMapping>(
+        z.object<FromType<TestBodyMapping>>({
+          name: z.string(),
+          age: z.number(),
+        }),
+      );
+
+      const next = jest.fn();
+
+      expect(
+        await middleware.invoke({
+          provider: {
+            id: 'provider:aws',
+
+            payload: partial<Event.Payload<'apigw:proxy:v2'>>({
+              body: '{b"r[o]ke"n}}',
+            }),
+          },
+
+          context: 'given-context' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+          next,
+        }),
+      ).toStrictEqual<HttpRequestBodyValidatorErrorResponse>({
+        type: 'response:http',
+
+        value: {
+          status: 400,
+          body: undefined,
+        },
+      });
+
+      expect(next).toBeCalledTimes(0);
+    });
+
+    it('with body, json deocded, zod schema invalid, returns error', async (): Promise<void> => {
+      type TestBodyMapping = {
+        name: string;
+        age: number;
+      };
+
+      const middleware = HttpRequestBodyValidatorMiddleware.zod<TestBodyMapping>(
+        z.object<FromType<TestBodyMapping>>({
+          name: z.string(),
+          age: z.number(),
+        }),
+      );
+
+      const next = jest.fn();
+
+      expect(
+        await middleware.invoke({
+          provider: {
+            id: 'provider:aws',
+
+            payload: partial<Event.Payload<'apigw:proxy:v2'>>({
+              body: JSON.stringify({}),
+            }),
+          },
+
+          context: 'given-context' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+          next,
+        }),
+      ).toStrictEqual<HttpRequestBodyValidatorErrorResponse>({
+        type: 'response:http',
+
+        value: {
+          status: 400,
+          body: [
+            expect.objectContaining<Partial<ZodIssue>>({
+              code: 'invalid_type',
+              message: 'Required',
+              received: 'undefined',
+              path: ['name'],
+            }),
+            expect.objectContaining<Partial<ZodIssue>>({
+              code: 'invalid_type',
+              message: 'Required',
+              received: 'undefined',
+              path: ['age'],
+            }),
+          ],
+        },
+      });
+
+      expect(next).toBeCalledTimes(0);
+    });
+
+    it('with body, json deocded, zod schema validates, invokes next with context', async (): Promise<void> => {
+      type TestBodyMapping = {
+        name: string;
+        age: number;
+      };
+
+      const middleware = HttpRequestBodyValidatorMiddleware.zod<TestBodyMapping>(
+        z.object<FromType<TestBodyMapping>>({
+          name: z.string(),
+          age: z.number(),
+        }),
+      );
+
+      const next = jest.fn();
+
+      next.mockImplementationOnce(async (context: HttpRequestBodyValidatorContext<unknown>): Promise<HandlerResponseConstraint> => {
+        expect(context.body).toStrictEqual<TestBodyMapping>({
+          name: 'some-name',
+          age: 40,
+        });
+
+        return {
+          type: 'response:example',
+          value: 'test-action:middleware:next:success',
+        };
+      });
+
+      expect(
+        await middleware.invoke({
+          provider: {
+            id: 'provider:aws',
+
+            payload: partial<Event.Payload<'apigw:proxy:v2'>>({
+              body: JSON.stringify({
+                name: 'some-name',
+                age: 40,
+              }),
+            }),
+          },
+
+          context: 'given-context' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+          next,
+        }),
+      ).toStrictEqual<HandlerResponseConstraint>({
+        type: 'response:example',
+        value: 'test-action:middleware:next:success',
+      });
+
+      expect(next).toBeCalledTimes(1);
+    });
+  });
+});

--- a/packages/@phasma/handler-aws/src/http/middlware/http-request-body-validator.ts
+++ b/packages/@phasma/handler-aws/src/http/middlware/http-request-body-validator.ts
@@ -1,0 +1,78 @@
+import { Grok } from '@matt-usurp/grok';
+import type { HttpBodyDecoder } from '@phasma/handler/src/http/body';
+import { decode as json } from '@phasma/handler/src/http/body/json';
+import { http, HttpResponse, HttpResponseTransport, HttpResponseTransportKind } from '@phasma/handler/src/http/response';
+import { HttpValidatorFunction } from '@phasma/handler/src/http/validator';
+import { validate, ZodSchema } from '@phasma/handler/src/http/validator/zod';
+import type { Middleware, Provider } from '../../index';
+
+export type HttpRequestBodyValidatorErrorResponse = HttpResponse<HttpResponseTransport<400, unknown>>;
+
+export type HttpRequestBodyValidatorContext<T> = {
+  readonly body: T;
+};
+
+export type HttpRequestBodyValidatorMiddlewareDefinition<T> = (
+/* eslint-disable @typescript-eslint/indent */
+  Middleware.Definition<
+    Provider.WithEventSource<'apigw:proxy:v2'>,
+    Middleware.Definition.SomeContextInbound,
+    HttpRequestBodyValidatorContext<T>,
+    Middleware.Definition.SomeResponseInbound,
+    HttpResponse<HttpResponseTransportKind>
+  >
+/* eslint-enable @typescript-eslint/indent */
+);
+
+export class HttpRequestBodyValidatorMiddleware<T> implements Middleware.Implementation<HttpRequestBodyValidatorMiddlewareDefinition<T>> {
+  public static zod<T>(schema: ZodSchema): HttpRequestBodyValidatorMiddleware<T> {
+    return new HttpRequestBodyValidatorMiddleware(json, validate(schema));
+  }
+
+  public static create<T>(
+    decoder: HttpBodyDecoder<Grok.Constraint.ObjectLike>,
+    validator: HttpValidatorFunction<Grok.Constraint.ObjectLike, unknown>,
+  ): HttpRequestBodyValidatorMiddleware<T> {
+    return new HttpRequestBodyValidatorMiddleware(decoder, validator);
+  }
+
+  protected constructor(
+    public readonly decoder: HttpBodyDecoder<Grok.Constraint.ObjectLike>,
+    public readonly validator: HttpValidatorFunction<Grok.Constraint.ObjectLike, unknown>,
+  ) {}
+
+  public async invoke({ provider, context, next }: Middleware.Fn.Parameters<HttpRequestBodyValidatorMiddlewareDefinition<T>>): Middleware.Fn.Response<HttpRequestBodyValidatorMiddlewareDefinition<T>> {
+    const body = provider.payload?.body;
+
+    if (body === undefined || body === '') {
+      return http({
+        status: 400,
+        body: undefined,
+      });
+    }
+
+    const payload = this.decoder(body);
+
+    if (payload === undefined) {
+      return http({
+        status: 400,
+        body: undefined,
+      });
+    }
+
+    const result = this.validator(payload);
+
+    if (result.success === false) {
+      return http({
+        status: 400,
+        body: result.errors,
+      });
+    }
+
+    return next({
+      ...context,
+
+      body: result.data as unknown as T,
+    });
+  }
+}

--- a/packages/@phasma/handler-aws/src/http/middlware/http-request-path-validator.test.ts
+++ b/packages/@phasma/handler-aws/src/http/middlware/http-request-path-validator.test.ts
@@ -1,0 +1,249 @@
+import type { Grok } from '@matt-usurp/grok';
+import { fn, partial } from '@matt-usurp/grok/testing';
+import type { HandlerResponseConstraint } from '@phasma/handler/src/component/response';
+import type { HttpValidatorFunction, HttpValidatorFunctionResultFailure, HttpValidatorFunctionResultSuccess } from '@phasma/handler/src/http/validator';
+import { FromType } from '@phasma/handler/src/http/validator/zod';
+import { z, ZodIssue } from 'zod';
+import type { Event } from '../../index';
+import { HttpRequestPathValidatorContext, HttpRequestPathValidatorErrorResponse, HttpRequestPathValidatorMiddleware } from './http-request-path-validator';
+
+describe(HttpRequestPathValidatorMiddleware.name, (): void => {
+  describe('create()', (): void => {
+    it('with path, undefined, return error', async (): Promise<void> => {
+      const validator = fn<HttpValidatorFunction<Grok.Constraint.Anything, unknown>>();
+
+      const middleware = HttpRequestPathValidatorMiddleware.create(validator);
+
+      const next = jest.fn();
+
+      expect(
+        await middleware.invoke({
+          // Provider is ignore for this middleware
+          provider: {
+            id: 'provider:aws',
+
+            payload: partial<Event.Payload<'apigw:proxy:v2'>>({
+              pathParameters: undefined,
+            }),
+          },
+
+          // Context is ignored for this middleware
+          context: 'given-context' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+          next,
+        }),
+      ).toStrictEqual<HttpRequestPathValidatorErrorResponse>({
+        type: 'response:http',
+
+        value: {
+          status: 400,
+          body: undefined,
+        },
+      });
+
+      expect(validator).toBeCalledTimes(0);
+
+      expect(next).toBeCalledTimes(0);
+    });
+
+    it('with path, validator returns error, return error', async (): Promise<void> => {
+      const validator = fn<HttpValidatorFunction<Grok.Constraint.Anything, unknown>>();
+
+      validator.mockImplementationOnce((value: unknown): HttpValidatorFunctionResultFailure<unknown> => {
+        expect(value).toStrictEqual('value:provider:payload:path:invalid');
+
+        return {
+          success: false,
+          errors: 'test-action:validator:errors',
+        };
+      });
+
+      const middleware = HttpRequestPathValidatorMiddleware.create(validator);
+
+      const next = jest.fn();
+
+      expect(
+        await middleware.invoke({
+          // Provider is ignore for this middleware
+          provider: {
+            id: 'provider:aws',
+
+            payload: partial<Event.Payload<'apigw:proxy:v2'>>({
+              pathParameters: 'value:provider:payload:path:invalid' as unknown as Record<string, string>,
+            }),
+          },
+
+          // Context is ignored for this middleware
+          context: 'given-context' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+          next,
+        }),
+      ).toStrictEqual<HttpRequestPathValidatorErrorResponse>({
+        type: 'response:http',
+
+        value: {
+          status: 400,
+          body: 'test-action:validator:errors',
+        },
+      });
+
+      expect(validator).toBeCalledTimes(1);
+
+      expect(next).toBeCalledTimes(0);
+    });
+
+    it('with path, validates, calls next with context', async (): Promise<void> => {
+      const validator = fn<HttpValidatorFunction<Grok.Constraint.Anything, unknown>>();
+
+      validator.mockImplementationOnce((value: unknown): HttpValidatorFunctionResultSuccess<unknown> => {
+        expect(value).toStrictEqual({
+          foo: 'bar',
+        });
+
+        return {
+          success: true,
+          data: 'test-action:validator:success',
+        };
+      });
+
+      const middleware = HttpRequestPathValidatorMiddleware.create(validator);
+
+      const next = jest.fn();
+
+      next.mockImplementationOnce(async (context: HttpRequestPathValidatorContext<unknown>): Promise<HandlerResponseConstraint> => {
+        expect(context.path).toStrictEqual('test-action:validator:success');
+
+        return {
+          type: 'response:example',
+          value: 'test-action:middleware:next:success',
+        };
+      });
+
+      expect(
+        await middleware.invoke({
+          // Provider is ignore for this middleware
+          provider: {
+            id: 'provider:aws',
+
+            payload: partial<Event.Payload<'apigw:proxy:v2'>>({
+              pathParameters: {
+                foo: 'bar',
+              },
+            }),
+          },
+
+          // Context is ignored for this middleware
+          context: 'given-context' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+          next,
+        }),
+      ).toStrictEqual<HandlerResponseConstraint>({
+        type: 'response:example',
+        value: 'test-action:middleware:next:success',
+      });
+
+      expect(validator).toBeCalledTimes(1);
+
+      expect(next).toBeCalledTimes(1);
+    });
+  });
+
+  describe('zod()', (): void => {
+    it('with body, zod schema invalid, returns error', async (): Promise<void> => {
+      type TestPathMapping = {
+        user: string;
+        session: string;
+      };
+
+      const middleware = HttpRequestPathValidatorMiddleware.zod<TestPathMapping>(
+        z.object<FromType<TestPathMapping>>({
+          user: z.string(),
+          session: z.string(),
+        }),
+      );
+
+      const next = jest.fn();
+
+      expect(
+        await middleware.invoke({
+          provider: {
+            id: 'provider:aws',
+
+            payload: partial<Event.Payload<'apigw:proxy:v2'>>({
+              pathParameters: {
+                user: 'some-user',
+              },
+            }),
+          },
+
+          context: 'given-context' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+          next,
+        }),
+      ).toStrictEqual<HttpRequestPathValidatorErrorResponse>({
+        type: 'response:http',
+
+        value: {
+          status: 400,
+          body: [
+            expect.objectContaining<Partial<ZodIssue>>({
+              code: 'invalid_type',
+              message: 'Required',
+              received: 'undefined',
+              path: ['session'],
+            }),
+          ],
+        },
+      });
+
+      expect(next).toBeCalledTimes(0);
+    });
+
+    it('with body, zod schema validates, invokes next with context', async (): Promise<void> => {
+      type TestPathMapping = {
+        user: string;
+        session: string;
+      };
+
+      const middleware = HttpRequestPathValidatorMiddleware.zod<TestPathMapping>(
+        z.object<FromType<TestPathMapping>>({
+          user: z.string(),
+          session: z.string(),
+        }),
+      );
+
+      const next = jest.fn();
+
+      next.mockImplementationOnce(async (context: HttpRequestPathValidatorContext<unknown>): Promise<HandlerResponseConstraint> => {
+        expect(context.path).toStrictEqual<TestPathMapping>({
+          user: 'some-user',
+          session: 'some-session',
+        });
+
+        return {
+          type: 'response:example',
+          value: 'test-action:middleware:next:success',
+        };
+      });
+
+      expect(
+        await middleware.invoke({
+          provider: {
+            id: 'provider:aws',
+
+            payload: partial<Event.Payload<'apigw:proxy:v2'>>({
+              pathParameters: {
+                user: 'some-user',
+                session: 'some-session',
+              },
+            }),
+          },
+
+          context: 'given-context' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+          next,
+        }),
+      ).toStrictEqual<HandlerResponseConstraint>({
+        type: 'response:example',
+        value: 'test-action:middleware:next:success',
+      });
+
+      expect(next).toBeCalledTimes(1);
+    });
+  });
+});

--- a/packages/@phasma/handler-aws/src/http/middlware/http-request-path-validator.ts
+++ b/packages/@phasma/handler-aws/src/http/middlware/http-request-path-validator.ts
@@ -1,0 +1,63 @@
+import type { Grok } from '@matt-usurp/grok';
+import { http, HttpResponse, HttpResponseTransport, HttpResponseTransportKind } from '@phasma/handler/src/http/response';
+import type { HttpValidatorFunction } from '@phasma/handler/src/http/validator';
+import { validate, ZodSchema } from '@phasma/handler/src/http/validator/zod';
+import type { Middleware, Provider } from '../../index';
+
+export type HttpRequestPathValidatorErrorResponse = HttpResponse<HttpResponseTransport<400, unknown>>;
+
+export type HttpRequestPathValidatorContext<T> = {
+  readonly path: T;
+};
+
+export type HttpRequestPathValidatorMiddlewareDefinition<T> = (
+/* eslint-disable @typescript-eslint/indent */
+  Middleware.Definition<
+    Provider.WithEventSource<'apigw:proxy:v2'>,
+    Middleware.Definition.SomeContextInbound,
+    HttpRequestPathValidatorContext<T>,
+    Middleware.Definition.SomeResponseInbound,
+    HttpResponse<HttpResponseTransportKind>
+  >
+/* eslint-enable @typescript-eslint/indent */
+);
+
+export class HttpRequestPathValidatorMiddleware<T extends Grok.Constraint.ObjectLike> implements Middleware.Implementation<HttpRequestPathValidatorMiddlewareDefinition<T>> {
+  public static zod<T extends Grok.Constraint.ObjectLike>(schema: ZodSchema): HttpRequestPathValidatorMiddleware<T> {
+    return new HttpRequestPathValidatorMiddleware<T>(validate(schema));
+  }
+
+  public static create<T extends Grok.Constraint.ObjectLike>(validator: HttpValidatorFunction<Grok.Constraint.ObjectLike, unknown>): HttpRequestPathValidatorMiddleware<T> {
+    return new HttpRequestPathValidatorMiddleware(validator);
+  }
+
+  protected constructor(
+    public readonly validator: HttpValidatorFunction<Grok.Constraint.ObjectLike, unknown>,
+  ) {}
+
+  public async invoke({ provider, context, next }: Middleware.Fn.Parameters<HttpRequestPathValidatorMiddlewareDefinition<T>>): Middleware.Fn.Response<HttpRequestPathValidatorMiddlewareDefinition<T>> {
+    const query = provider.payload?.pathParameters;
+
+    if (query === undefined) {
+      return http({
+        status: 400,
+        body: undefined,
+      });
+    }
+
+    const result = this.validator(query);
+
+    if (result.success === false) {
+      return http({
+        status: 400,
+        body: result.errors,
+      });
+    }
+
+    return next({
+      ...context,
+
+      path: result.data as unknown as T,
+    });
+  }
+}

--- a/packages/@phasma/handler-aws/src/http/middlware/http-request-path-validator.ts
+++ b/packages/@phasma/handler-aws/src/http/middlware/http-request-path-validator.ts
@@ -36,16 +36,16 @@ export class HttpRequestPathValidatorMiddleware<T extends Grok.Constraint.Object
   ) {}
 
   public async invoke({ provider, context, next }: Middleware.Fn.Parameters<HttpRequestPathValidatorMiddlewareDefinition<T>>): Middleware.Fn.Response<HttpRequestPathValidatorMiddlewareDefinition<T>> {
-    const query = provider.payload?.pathParameters;
+    const path = provider.payload?.pathParameters;
 
-    if (query === undefined) {
+    if (path === undefined) {
       return http({
         status: 400,
         body: undefined,
       });
     }
 
-    const result = this.validator(query);
+    const result = this.validator(path);
 
     if (result.success === false) {
       return http({

--- a/packages/@phasma/handler-aws/src/http/middlware/http-request-query-validator.test.ts
+++ b/packages/@phasma/handler-aws/src/http/middlware/http-request-query-validator.test.ts
@@ -1,0 +1,354 @@
+import type { Grok } from '@matt-usurp/grok';
+import { fn, partial } from '@matt-usurp/grok/testing';
+import type { HandlerResponseConstraint } from '@phasma/handler/src/component/response';
+import type { HttpQueryParser } from '@phasma/handler/src/http/query';
+import type { HttpValidatorFunction, HttpValidatorFunctionResultFailure, HttpValidatorFunctionResultSuccess } from '@phasma/handler/src/http/validator';
+import type { FromType } from '@phasma/handler/src/http/validator/zod';
+import { z, ZodIssue } from 'zod';
+import type { Event } from '../../index';
+import { HttpRequesQueryValidatorMiddleware, HttpRequestQueryValidatorContext, HttpRequestQueryValidatorErrorResponse } from './http-request-query-validator';
+
+describe(HttpRequesQueryValidatorMiddleware.name, (): void => {
+  describe('create()', (): void => {
+    it('with query, undefined, return errors', async (): Promise<void> => {
+      const parser = fn<HttpQueryParser<Grok.Constraint.Anything>>();
+      const validator = fn<HttpValidatorFunction<Grok.Constraint.Anything, unknown>>();
+
+      parser.mockImplementationOnce((value: string) => {
+        expect(value).toStrictEqual('');
+
+        return undefined;
+      });
+
+      const middleware = HttpRequesQueryValidatorMiddleware.create<Grok.Constraint.Anything>(parser, validator);
+
+      const next = jest.fn();
+
+      expect(
+        await middleware.invoke({
+          provider: {
+            id: 'provider:aws',
+
+            payload: partial<Event.Payload<'apigw:proxy:v2'>>({
+              rawQueryString: undefined,
+            }),
+          },
+
+          context: 'given-context' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+          next,
+        }),
+      ).toStrictEqual<HttpRequestQueryValidatorErrorResponse>({
+        type: 'response:http',
+
+        value: {
+          status: 400,
+          body: undefined,
+        },
+      });
+
+      expect(parser).toBeCalledTimes(1);
+      expect(validator).toBeCalledTimes(0);
+
+      expect(next).toBeCalledTimes(0);
+    });
+
+    it('with query, query parser errors, return errors', async (): Promise<void> => {
+      const parser = fn<HttpQueryParser<Grok.Constraint.Anything>>();
+      const validator = fn<HttpValidatorFunction<Grok.Constraint.Anything, unknown>>();
+
+      parser.mockImplementationOnce((value: string) => {
+        expect(value).toStrictEqual('value:provider:payload:query:invalid');
+
+        return undefined;
+      });
+
+      const middleware = HttpRequesQueryValidatorMiddleware.create<Grok.Constraint.Anything>(parser, validator);
+
+      const next = jest.fn();
+
+      expect(
+        await middleware.invoke({
+          provider: {
+            id: 'provider:aws',
+
+            payload: partial<Event.Payload<'apigw:proxy:v2'>>({
+              rawQueryString: 'value:provider:payload:query:invalid',
+            }),
+          },
+
+          context: 'given-context' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+          next,
+        }),
+      ).toStrictEqual<HttpRequestQueryValidatorErrorResponse>({
+        type: 'response:http',
+
+        value: {
+          status: 400,
+          body: undefined,
+        },
+      });
+
+      expect(parser).toBeCalledTimes(1);
+      expect(validator).toBeCalledTimes(0);
+
+      expect(next).toBeCalledTimes(0);
+    });
+
+    it('with query, query parses, validator returns error, return errors', async (): Promise<void> => {
+      const parser = fn<HttpQueryParser<Grok.Constraint.Anything>>();
+      const validator = fn<HttpValidatorFunction<Grok.Constraint.Anything, unknown>>();
+
+      parser.mockImplementationOnce((value: string) => {
+        expect(value).toStrictEqual('value:provider:payload:query:invalid');
+
+        return 'test-action:parser:success';
+      });
+
+      validator.mockImplementationOnce((value: unknown): HttpValidatorFunctionResultFailure<unknown> => {
+        expect(value).toStrictEqual('test-action:parser:success');
+
+        return {
+          success: false,
+          errors: 'test-action:validator:errors',
+        };
+      });
+
+      const middleware = HttpRequesQueryValidatorMiddleware.create<Grok.Constraint.Anything>(parser, validator);
+
+      const next = jest.fn();
+
+      expect(
+        await middleware.invoke({
+          provider: {
+            id: 'provider:aws',
+
+            payload: partial<Event.Payload<'apigw:proxy:v2'>>({
+              rawQueryString: 'value:provider:payload:query:invalid',
+            }),
+          },
+
+          context: 'given-context' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+          next,
+        }),
+      ).toStrictEqual<HttpRequestQueryValidatorErrorResponse>({
+        type: 'response:http',
+
+        value: {
+          status: 400,
+          body: 'test-action:validator:errors',
+        },
+      });
+
+      expect(parser).toBeCalledTimes(1);
+      expect(validator).toBeCalledTimes(1);
+
+      expect(next).toBeCalledTimes(0);
+    });
+
+    it('with query, query parses, validator passes, invokes next with context', async (): Promise<void> => {
+      const parser = fn<HttpQueryParser<Grok.Constraint.Anything>>();
+      const validator = fn<HttpValidatorFunction<Grok.Constraint.Anything, unknown>>();
+
+      parser.mockImplementationOnce((value: string) => {
+        expect(value).toStrictEqual('value:provider:payload:raw-query-string:valid');
+
+        return 'test-action:parser:success';
+      });
+
+      validator.mockImplementationOnce((value: unknown): HttpValidatorFunctionResultSuccess<unknown> => {
+        expect(value).toStrictEqual('test-action:parser:success');
+
+        return {
+          success: true,
+          data: 'test-action:validator:success',
+        };
+      });
+
+      const middleware = HttpRequesQueryValidatorMiddleware.create<Grok.Constraint.Anything>(parser, validator);
+
+      const next = jest.fn();
+
+      next.mockImplementationOnce(async (context: HttpRequestQueryValidatorContext<unknown>): Promise<HandlerResponseConstraint> => {
+        expect(context.query).toStrictEqual('test-action:validator:success');
+
+        return {
+          type: 'response:example',
+          value: 'test-action:middleware:next:success',
+        };
+      });
+
+      expect(
+        await middleware.invoke({
+          provider: {
+            id: 'provider:aws',
+
+            payload: partial<Event.Payload<'apigw:proxy:v2'>>({
+              rawQueryString: 'value:provider:payload:raw-query-string:valid',
+            }),
+          },
+
+          context: 'given-context' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+          next,
+        }),
+      ).toStrictEqual<HandlerResponseConstraint>({
+        type: 'response:example',
+        value: 'test-action:middleware:next:success',
+      });
+
+      expect(parser).toBeCalledTimes(1);
+      expect(validator).toBeCalledTimes(1);
+
+      expect(next).toBeCalledTimes(1);
+    });
+  });
+
+  describe('zod()', (): void => {
+    it('with query, query parser errors, returns error', async (): Promise<void> => {
+      type TestQueryMapping = {
+        foo: string;
+        bar: string;
+      };
+
+      const middleware = HttpRequesQueryValidatorMiddleware.zod<TestQueryMapping>(
+        z.object<FromType<TestQueryMapping>>({
+          foo: z.string(),
+          bar: z.string(),
+        }),
+      );
+
+      const next = jest.fn();
+
+      expect(
+        await middleware.invoke({
+          provider: {
+            id: 'provider:aws',
+
+            payload: partial<Event.Payload<'apigw:proxy:v2'>>({
+              rawQueryString: '<foo><bar>',
+            }),
+          },
+
+          context: 'given-context' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+          next,
+        }),
+      ).toStrictEqual<HttpRequestQueryValidatorErrorResponse>({
+        type: 'response:http',
+
+        value: {
+          status: 400,
+          body: [
+            expect.objectContaining<Partial<ZodIssue>>({
+              code: 'invalid_type',
+              message: 'Required',
+              received: 'undefined',
+              path: ['foo'],
+            }),
+            expect.objectContaining<Partial<ZodIssue>>({
+              code: 'invalid_type',
+              message: 'Required',
+              received: 'undefined',
+              path: ['bar'],
+            }),
+          ],
+        },
+      });
+
+      expect(next).toBeCalledTimes(0);
+    });
+
+    it('with query, query parses, zod schema invalid, returns error', async (): Promise<void> => {
+      type TestQueryMapping = {
+        foo: string;
+        bar: string;
+      };
+
+      const middleware = HttpRequesQueryValidatorMiddleware.zod<TestQueryMapping>(
+        z.object<FromType<TestQueryMapping>>({
+          foo: z.string(),
+          bar: z.string(),
+        }),
+      );
+
+      const next = jest.fn();
+
+      expect(
+        await middleware.invoke({
+          provider: {
+            id: 'provider:aws',
+
+            payload: partial<Event.Payload<'apigw:proxy:v2'>>({
+              rawQueryString: 'foo=a',
+            }),
+          },
+
+          context: 'given-context' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+          next,
+        }),
+      ).toStrictEqual<HttpRequestQueryValidatorErrorResponse>({
+        type: 'response:http',
+
+        value: {
+          status: 400,
+          body: [
+            expect.objectContaining<Partial<ZodIssue>>({
+              code: 'invalid_type',
+              message: 'Required',
+              received: 'undefined',
+              path: ['bar'],
+            }),
+          ],
+        },
+      });
+
+      expect(next).toBeCalledTimes(0);
+    });
+
+    it('with query, query parses, zod schema validates, invokes next with context', async (): Promise<void> => {
+      type TestQueryMapping = {
+        foo: string;
+        bar: string;
+      };
+
+      const middleware = HttpRequesQueryValidatorMiddleware.zod<TestQueryMapping>(
+        z.object<FromType<TestQueryMapping>>({
+          foo: z.string(),
+          bar: z.string(),
+        }),
+      );
+
+      const next = jest.fn();
+
+      next.mockImplementationOnce(async (context: HttpRequestQueryValidatorContext<unknown>): Promise<HandlerResponseConstraint> => {
+        expect(context.query).toStrictEqual<TestQueryMapping>({
+          foo: 'a',
+          bar: 'b',
+        });
+
+        return {
+          type: 'response:example',
+          value: 'test-action:middleware:next:success',
+        };
+      });
+
+      expect(
+        await middleware.invoke({
+          provider: {
+            id: 'provider:aws',
+
+            payload: partial<Event.Payload<'apigw:proxy:v2'>>({
+              rawQueryString: 'foo=a&bar=b',
+            }),
+          },
+
+          context: 'given-context' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+          next,
+        }),
+      ).toStrictEqual<HandlerResponseConstraint>({
+        type: 'response:example',
+        value: 'test-action:middleware:next:success',
+      });
+
+      expect(next).toBeCalledTimes(1);
+    });
+  });
+});

--- a/packages/@phasma/handler-aws/src/http/middlware/http-request-query-validator.ts
+++ b/packages/@phasma/handler-aws/src/http/middlware/http-request-query-validator.ts
@@ -1,0 +1,70 @@
+import type { Grok } from '@matt-usurp/grok';
+import type { HttpQueryParser } from '@phasma/handler/src/http/query';
+import { parse as query } from '@phasma/handler/src/http/query';
+import { http, HttpResponse, HttpResponseTransport, HttpResponseTransportKind } from '@phasma/handler/src/http/response';
+import type { HttpValidatorFunction } from '@phasma/handler/src/http/validator';
+import { validate, ZodSchema } from '@phasma/handler/src/http/validator/zod';
+import type { Middleware, Provider } from '../../index';
+
+export type HttpRequestQueryValidatorErrorResponse = HttpResponse<HttpResponseTransport<400, unknown>>;
+
+export type HttpRequestQueryValidatorContext<T> = {
+  readonly query: T;
+};
+
+export type HttpRequesQueryValidatorMiddlewareDefinition<T> = (
+/* eslint-disable @typescript-eslint/indent */
+  Middleware.Definition<
+    Provider.WithEventSource<'apigw:proxy:v2'>,
+    Middleware.Definition.SomeContextInbound,
+    HttpRequestQueryValidatorContext<T>,
+    Middleware.Definition.SomeResponseInbound,
+    HttpResponse<HttpResponseTransportKind>
+  >
+/* eslint-enable @typescript-eslint/indent */
+);
+
+export class HttpRequesQueryValidatorMiddleware<T extends Grok.Constraint.ObjectLike> implements Middleware.Implementation<HttpRequesQueryValidatorMiddlewareDefinition<T>> {
+  public static zod<T extends Grok.Constraint.ObjectLike>(schema: ZodSchema): HttpRequesQueryValidatorMiddleware<T> {
+    return new HttpRequesQueryValidatorMiddleware(query, validate(schema));
+  }
+
+  public static create<T extends Grok.Constraint.ObjectLike>(
+    parser: HttpQueryParser<Grok.Constraint.ObjectLike>,
+    validator: HttpValidatorFunction<Grok.Constraint.ObjectLike, unknown>,
+  ): HttpRequesQueryValidatorMiddleware<T> {
+    return new HttpRequesQueryValidatorMiddleware(parser, validator);
+  }
+
+  protected constructor(
+    public readonly parser: HttpQueryParser<Grok.Constraint.ObjectLike>,
+    public readonly validator: HttpValidatorFunction<Grok.Constraint.ObjectLike, unknown>,
+  ) {}
+
+  public async invoke({ provider, context, next }: Middleware.Fn.Parameters<HttpRequesQueryValidatorMiddlewareDefinition<T>>): Middleware.Fn.Response<HttpRequesQueryValidatorMiddlewareDefinition<T>> {
+    const query = provider.payload?.rawQueryString ?? '';
+    const parsed = this.parser(query);
+
+    if (parsed === undefined) {
+      return http({
+        status: 400,
+        body: undefined,
+      });
+    }
+
+    const result = this.validator(parsed);
+
+    if (result.success === false) {
+      return http({
+        status: 400,
+        body: result.errors,
+      });
+    }
+
+    return next({
+      ...context,
+
+      query: result.data as unknown as T,
+    });
+  }
+}

--- a/packages/@phasma/handler-aws/src/http/middlware/http-response-body-encoder.test.ts
+++ b/packages/@phasma/handler-aws/src/http/middlware/http-response-body-encoder.test.ts
@@ -1,5 +1,5 @@
 import type { HandlerResponse } from '@phasma/handler/src/component/response';
-import * as body from '@phasma/handler/src/http/body';
+import { encode as json } from '@phasma/handler/src/http/body/json';
 import { http, HttpResponse, HttpResponseTransport } from '@phasma/handler/src/http/response';
 import { HttpBodyObjectTransport, HttpResponseBodyEncoderMiddleware } from './http-response-body-encoder';
 
@@ -9,84 +9,88 @@ type TestJsonResponseTransport = {
 };
 
 describe(HttpResponseBodyEncoderMiddleware.name, (): void => {
-  it('using static factory, json, returns middleware with json encoding', (): void => {
-    const middleware = HttpResponseBodyEncoderMiddleware.json();
+  describe('create()', (): void => {
+    it('using json transformer, given object, return json encoded http response', async (): Promise<void> => {
+      const middleware = HttpResponseBodyEncoderMiddleware.create(json);
 
-    expect(middleware.encoder).toStrictEqual(body.json);
-  });
+      const next = jest.fn();
 
-  it('using json transformer, given object, return json encoded http response', async (): Promise<void> => {
-    const middleware = new HttpResponseBodyEncoderMiddleware(body.json);
+      next.mockImplementationOnce(async (): Promise<HttpResponse<HttpResponseTransport<200, TestJsonResponseTransport>>> => {
+        return http({
+          status: 200,
+          body: {
+            song: '1985',
+            artist: 'Bowling For Soup',
+          },
+        });
+      });
 
-    const next = jest.fn();
+      expect(
+        await middleware.invoke({
+          // Provider is ignore for this middleware
+          provider: 'given-provider',
 
-    next.mockImplementationOnce(async (): Promise<HttpResponse<HttpResponseTransport<200, TestJsonResponseTransport>>> => {
-      return http({
-        status: 200,
-        body: {
-          song: '1985',
-          artist: 'Bowling For Soup',
+          // Context is ignored for this middleware
+          context: 'given-context' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+          next,
+        }),
+      ).toStrictEqual<HttpResponse<HttpBodyObjectTransport>>({
+        type: 'response:http',
+        value: {
+          status: 200,
+
+          headers: {
+            'content-type': 'application/json',
+            'content-length': 43,
+          },
+
+          body: JSON.stringify({
+            song: '1985',
+            artist: 'Bowling For Soup',
+          }),
         },
       });
+
+      expect(next).toBeCalledTimes(1);
+      expect(next).toBeCalledWith('given-context');
     });
 
-    expect(
-      await middleware.invoke({
-        // Provider is ignore for this middleware
-        provider: 'given-provider',
+    it('with unknown response, returns unknown response', async (): Promise<void> => {
+      const middleware = HttpResponseBodyEncoderMiddleware.create(json);
 
-        // Context is ignored for this middleware
-        context: 'given-context' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-        next,
-      }),
-    ).toStrictEqual<HttpResponse<HttpBodyObjectTransport>>({
-      type: 'response:http',
-      value: {
-        status: 200,
+      const next = jest.fn();
 
-        headers: {
-          'content-type': 'application/json',
-          'content-length': 43,
-        },
+      next.mockImplementationOnce(async (): Promise<HandlerResponse<'response:unknown', 1000>> => {
+        return {
+          type: 'response:unknown',
+          value: 1000,
+        };
+      });
 
-        body: JSON.stringify({
-          song: '1985',
-          artist: 'Bowling For Soup',
+      expect(
+        await middleware.invoke({
+          // Provider is ignore for this middleware
+          provider: 'given-provider',
+
+          // Context is ignored for this middleware
+          context: 'given-context' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+          next,
         }),
-      },
-    });
-
-    expect(next).toBeCalledTimes(1);
-    expect(next).toBeCalledWith('given-context');
-  });
-
-  it('with unknown response, returns unknown response', async (): Promise<void> => {
-    const middleware = new HttpResponseBodyEncoderMiddleware(body.json);
-
-    const next = jest.fn();
-
-    next.mockImplementationOnce(async (): Promise<HandlerResponse<'response:unknown', 1000>> => {
-      return {
+      ).toStrictEqual<HandlerResponse<'response:unknown', 1000>>({
         type: 'response:unknown',
         value: 1000,
-      };
+      });
+
+      expect(next).toBeCalledTimes(1);
+      expect(next).toBeCalledWith('given-context');
     });
+  });
 
-    expect(
-      await middleware.invoke({
-        // Provider is ignore for this middleware
-        provider: 'given-provider',
+  describe('json()', (): void => {
+    it('using static factory, json, returns middleware with json encoding', (): void => {
+      const middleware = HttpResponseBodyEncoderMiddleware.json();
 
-        // Context is ignored for this middleware
-        context: 'given-context' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-        next,
-      }),
-    ).toStrictEqual<HandlerResponse<'response:unknown', 1000>>({
-      type: 'response:unknown',
-      value: 1000,
+      expect(middleware.encoder).toStrictEqual(json);
     });
-
-    expect(next).toBeCalledTimes(1);
-    expect(next).toBeCalledWith('given-context');
   });
 });

--- a/packages/@phasma/handler-aws/src/http/middlware/http-response-body-encoder.ts
+++ b/packages/@phasma/handler-aws/src/http/middlware/http-response-body-encoder.ts
@@ -1,5 +1,6 @@
 import type { Grok } from '@matt-usurp/grok';
-import { HttpBodyEncoder, json } from '@phasma/handler/src/http/body';
+import type { HttpBodyEncoder } from '@phasma/handler/src/http/body';
+import { encode as json } from '@phasma/handler/src/http/body/json';
 import { ensure } from '@phasma/handler/src/http/header';
 import { http, HttpResponse, HttpResponseEncodedTransport, HttpResponseTransport } from '@phasma/handler/src/http/response';
 import { unwrap } from '@phasma/handler/src/response';
@@ -20,14 +21,15 @@ export type HttpTransformerMiddlewareDefinition<R extends HttpBodyObjectTranspor
 );
 
 export class HttpResponseBodyEncoderMiddleware<R extends HttpBodyObjectTransport> implements Middleware.Implementation<HttpTransformerMiddlewareDefinition<R>> {
-  /**
-   * Create a HTTP body transformer with the JSON encoding.
-   */
   public static json<R extends HttpBodyObjectTransport>(): HttpResponseBodyEncoderMiddleware<R> {
     return new HttpResponseBodyEncoderMiddleware(json);
   }
 
-  public constructor(
+  public static create<R extends HttpBodyObjectTransport>(encoder: HttpBodyEncoder): HttpResponseBodyEncoderMiddleware<R> {
+    return new HttpResponseBodyEncoderMiddleware(encoder);
+  }
+
+  protected constructor(
     public readonly encoder: HttpBodyEncoder,
   ) {}
 

--- a/packages/@phasma/handler-aws/src/http/middlware/http-response-transformer.test.ts
+++ b/packages/@phasma/handler-aws/src/http/middlware/http-response-transformer.test.ts
@@ -3,67 +3,63 @@ import { http, HttpResponse } from '@phasma/handler/src/http/response';
 import { HttpResponseLambdaProxy, HttpResponseTransformerMiddleware } from './http-response-transformer';
 
 describe(HttpResponseTransformerMiddleware.name, (): void => {
-  it('with http response, returns lambda response response', async (): Promise<void> => {
-    const middleware = new HttpResponseTransformerMiddleware();
+  describe('create()', (): void => {
+    it('with http response, returns lambda response response', async (): Promise<void> => {
+      const middleware = HttpResponseTransformerMiddleware.create();
 
-    const next = jest.fn();
+      const next = jest.fn();
 
-    next.mockImplementationOnce(async (): Promise<HttpResponse> => {
-      return http({
-        status: 204,
-        body: undefined,
+      next.mockImplementationOnce(async (): Promise<HttpResponse> => {
+        return http({
+          status: 204,
+          body: undefined,
+        });
       });
+
+      expect(
+        await middleware.invoke({
+          provider: 'given-provider',
+          context: 'given-context' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+          next,
+        }),
+      ).toStrictEqual<HttpResponseLambdaProxy>({
+        type: 'response:aws:result',
+        value: {
+          statusCode: 204,
+          headers: {},
+          body: undefined,
+        },
+      });
+
+      expect(next).toBeCalledTimes(1);
+      expect(next).toBeCalledWith('given-context');
     });
 
-    expect(
-      await middleware.invoke({
-        // Provider is ignore for this middleware
-        provider: 'given-provider',
+    it('with unknown response, returns unknown response', async (): Promise<void> => {
+      const middleware = HttpResponseTransformerMiddleware.create();
 
-        // Context is ignored for this middleware
-        context: 'given-context' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-        next,
-      }),
-    ).toStrictEqual<HttpResponseLambdaProxy>({
-      type: 'response:aws:result',
-      value: {
-        statusCode: 204,
-        headers: {},
-        body: undefined,
-      },
-    });
+      const next = jest.fn();
 
-    expect(next).toBeCalledTimes(1);
-    expect(next).toBeCalledWith('given-context');
-  });
+      next.mockImplementationOnce(async (): Promise<HandlerResponse<'response:unknown', 1000>> => {
+        return {
+          type: 'response:unknown',
+          value: 1000,
+        };
+      });
 
-  it('with unknown response, returns unknown response', async (): Promise<void> => {
-    const middleware = new HttpResponseTransformerMiddleware();
-
-    const next = jest.fn();
-
-    next.mockImplementationOnce(async (): Promise<HandlerResponse<'response:unknown', 1000>> => {
-      return {
+      expect(
+        await middleware.invoke({
+          provider: 'given-provider',
+          context: 'given-context' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+          next,
+        }),
+      ).toStrictEqual<HandlerResponse<'response:unknown', 1000>>({
         type: 'response:unknown',
         value: 1000,
-      };
+      });
+
+      expect(next).toBeCalledTimes(1);
+      expect(next).toBeCalledWith('given-context');
     });
-
-    expect(
-      await middleware.invoke({
-        // Provider is ignore for this middleware
-        provider: 'given-provider',
-
-        // Context is ignored for this middleware
-        context: 'given-context' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-        next,
-      }),
-    ).toStrictEqual<HandlerResponse<'response:unknown', 1000>>({
-      type: 'response:unknown',
-      value: 1000,
-    });
-
-    expect(next).toBeCalledTimes(1);
-    expect(next).toBeCalledWith('given-context');
   });
 });

--- a/packages/@phasma/handler-aws/src/http/middlware/http-response-transformer.ts
+++ b/packages/@phasma/handler-aws/src/http/middlware/http-response-transformer.ts
@@ -20,6 +20,13 @@ export type HttpResponseTransformerMiddlewareDefinition<R extends HttpResponseEn
 );
 
 export class HttpResponseTransformerMiddleware<R extends HttpResponseEncodedTransport> implements Middleware.Implementation<HttpResponseTransformerMiddlewareDefinition<R>> {
+  public static create<R extends HttpResponseEncodedTransport>(): HttpResponseTransformerMiddleware<R> {
+    return new HttpResponseTransformerMiddleware();
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  protected constructor() {}
+
   public async invoke({ context, next }: Middleware.Fn.Parameters<HttpResponseTransformerMiddlewareDefinition<R>>): Middleware.Fn.Response<HttpResponseTransformerMiddlewareDefinition<R>> {
     const value = await next(context);
 

--- a/packages/@phasma/handler/package.json
+++ b/packages/@phasma/handler/package.json
@@ -28,7 +28,7 @@
     }
   ],
   "dependencies": {
-    "@matt-usurp/grok": "^0.5.4",
+    "@matt-usurp/grok": "^0.6.1",
     "@types/aws-lambda": "^8.10.93"
   },
   "peerDependencies": {


### PR DESCRIPTION
Introduces 3 new middleware:
- `HttpRequestBodyValidatorMiddleware`
- `HttpRequestQueryValidatorMiddleware`
- `HttpRequestPathValidatorMiddleware`

These make use of `zod` and `qs` to help build type-safe HTTP capable handlers with ease!