### PR TITLE
feat(handler-aws): provide environment to compositions

### DIFF
--- a/packages/@phasma/handler-aws/src/core/provider.ts
+++ b/packages/@phasma/handler-aws/src/core/provider.ts
@@ -1,4 +1,5 @@
 import { never } from '@matt-usurp/grok';
+import type { EnvironmentMapping } from '@matt-usurp/grok/system/environment';
 import type { HandlerContextBase } from '@phasma/handler/src/component/context';
 import type { HandlerClassImplementation, HandlerComposition, HandlerEntrypoint } from '@phasma/handler/src/component/handler';
 import { HandlerComposer } from '@phasma/handler/src/core/handler/composer';
@@ -55,6 +56,19 @@ export type LambdaHandlerEntrypoint<EventSourceIdentifier extends LambdaHandlerE
 );
 
 /**
+ * Add a `withEnvironment()` function to {@link Entrypoint} that will create {@link Entrypoint} again with the environment provided.
+ */
+export type WithLambdaHandlerEntrypointUtilities<Entrypoint> = (
+  & Entrypoint
+  & {
+    /**
+     * Re-create the {@link Entrypoint} with the given {@link environment} instead.
+     */
+    withEnvironment: (environment: EnvironmentMapping) => Entrypoint;
+  }
+);
+
+/**
  * An entrypoint function that can be used to wrap the given composition from the builder.
  * This produces a function that is compatible with aws lambda.
  */
@@ -102,13 +116,22 @@ export const entrypoint = <EventSourceIdentifier extends LambdaHandlerEventSourc
   return fn;
 };
 
-export type LambdaHandlerCompositionFactory<EventSourceIdentifier extends LambdaHandlerEventSourceIdentifiers> = (application: LambdaHandlerComposer<EventSourceIdentifier>) => Promise<LambdaHandlerComposition<EventSourceIdentifier>>;
+/**
+ * Compose and return an {@link application} that will trigger the handler.
+ * Optionally make use of the given {@link environment} to allow for testing and abstractions.
+ */
+export type LambdaHandlerCompositionFactory<EventSourceIdentifier extends LambdaHandlerEventSourceIdentifiers> = (
+  application: LambdaHandlerComposer<EventSourceIdentifier>,
+  environment: EnvironmentMapping,
+) => Promise<LambdaHandlerComposition<EventSourceIdentifier>>;
 
 /**
  * A factory that can create handler compositions using the builder functionality provided.
  * This is the recommended entrypoint for building aws handlers.
  */
-export const factory = <EventSourceIdentifier extends LambdaHandlerEventSourceIdentifiers>(factory: LambdaHandlerCompositionFactory<EventSourceIdentifier>): LambdaHandlerEntrypoint<EventSourceIdentifier> => {
+export const factory = <EventSourceIdentifier extends LambdaHandlerEventSourceIdentifiers>(
+  composition: LambdaHandlerCompositionFactory<EventSourceIdentifier>,
+): WithLambdaHandlerEntrypointUtilities<LambdaHandlerEntrypoint<EventSourceIdentifier>> => {
   const composer: LambdaHandlerComposer<EventSourceIdentifier> = new HandlerComposer();
 
   // Essentially a cache that prevents the builder from being invoked multiple times.
@@ -116,11 +139,26 @@ export const factory = <EventSourceIdentifier extends LambdaHandlerEventSourceId
   // Now the builder is invoked only once on the first request.
   let invoker: LambdaHandlerEntrypoint<EventSourceIdentifier> | undefined = undefined;
 
-  return (payload, context) => {
+  // This is a proxy function that will allow for the entrypoint composition to be cached.
+  const proxy = (environment: EnvironmentMapping): LambdaHandlerEntrypoint<EventSourceIdentifier> => (payload, context) => {
     if (invoker === undefined) {
-      invoker = entrypoint(factory(composer));
+      invoker = entrypoint(
+        composition(
+          composer,
+          environment,
+        ),
+      );
     }
 
     return invoker(payload, context);
   };
+
+  // A production-like entrypoint is created using a reference to the process environment.
+  // This is cast to the utilities type which we add too before returning.
+  const handler = proxy(process.env) as WithLambdaHandlerEntrypointUtilities<LambdaHandlerEntrypoint<EventSourceIdentifier>>;
+
+  // Attach the custom environment factory utility.
+  handler.withEnvironment = (environment: EnvironmentMapping): LambdaHandlerEntrypoint<EventSourceIdentifier> => proxy(environment);
+
+  return handler;
 };


### PR DESCRIPTION
This introduces the `environment` parameter to the type `LambdaHandlerCompositionFactory` which will be provided with the `process.env` by default. Additionally, a utility method has been added to the response of `factory()`, allowing the handler composition to be invoked with a custom environment. This is useful for testing the handlers that require environment variables as part of their service construction.