### PR TITLE
feat(handler-aws): provide composition reset function

### DIFF
--- a/packages/@phasma/handler-aws/src/core/provider.test.ts
+++ b/packages/@phasma/handler-aws/src/core/provider.test.ts
@@ -295,4 +295,37 @@ describe('factory()', (): void => {
       FOOBAR: 'BAZ',
     });
   });
+
+  it('with handler, with cached compisition, can be reset', async (): Promise<void> => {
+    const instrument = vi.fn();
+
+    const wrapper = factory<'cloudwatch:log'>(async (application) => {
+      instrument();
+
+      return application.handle({
+        handle: async () => nothing(),
+      });
+    });
+
+    expect(instrument).toBeCalledTimes(0);
+
+    await wrapper(partial({}), context);
+
+    expect(instrument).toBeCalledTimes(1);
+
+    await wrapper(partial({}), context);
+    await wrapper(partial({}), context);
+    await wrapper(partial({}), context);
+
+    expect(instrument).toBeCalledTimes(1);
+
+    wrapper.reset();
+
+    await wrapper(partial({}), context);
+    await wrapper(partial({}), context);
+    await wrapper(partial({}), context);
+    await wrapper(partial({}), context);
+
+    expect(instrument).toBeCalledTimes(2);
+  });
 });


### PR DESCRIPTION
Provide a function on the entrypoint that will reset the underlying composition that is cached on the first invocation. Once invoked it was impossible to reset this, meaning if you were to use the newly introduced `withEnvironment()` helper the environment would not work because the composition was cached.